### PR TITLE
Add file upload, various ui improvements

### DIFF
--- a/app/root.js
+++ b/app/root.js
@@ -57,55 +57,96 @@ AppRoot.prototype.render = function () {
         }, 'Fork on Github'),
         h('br'),
 
-        h('label', {
-          htmlFor: 'fileinput',
-        }, 'Database backup'),
-        h('input.file', {
-          id: 'fileinput',
-          type: 'file',
-          placeholder: 'file',
-          onChange: async (event) => {
-            // TODO: Clear error
+        h('hr'),
 
-            if (event.target.files.length) {
-              const f = event.target.files[0]
-              // TODO: handle other format
-              // lmdb
-              const data = await f.text()
-              const vaultData = extractVaultFromLMDB(data)
-              this.setState({ vaultData })
-            }
-          },
-        }),
-        h('br'),
+        h('table', {}, [
+          h('tbody', {}, [
+            h('tr', {}, [
+              h('td', {}, [
+                h('input', {
+                  id: 'radio-fileinput',
+                  name: 'vault-source',
+                  type: 'radio',
+                  onChange: (event) => {
+                    if (event.target.checked) {
+                      this.setState({vaultSource: 'file'})
+                    }
+                  }
+                }),
+                h('label', {
+                  htmlFor: 'radio-fileinput',
+                }, 'Database backup'),
+              ]),
+              h('td', {}, [
+                h('input.file', {
+                  disabled: this.state.vaultSource !== 'file',
+                  id: 'fileinput',
+                  type: 'file',
+                  placeholder: 'file',
+                  onChange: async (event) => {
+                    // TODO: Clear error
 
-        h('textarea.vault-data', {
-          style: {
-            width: '600px',
-            height: '300px'
-          },
-          placeholder: 'Paste your vault data here.',
-          onChange: (event) => {
-            try {
-              const vaultData = JSON.parse(event.target.value)
-              if (
-                typeof vaultData !== 'object' ||
-                !['data', 'iv', 'salt'].every(e => Object.keys(vaultData).includes(e))
-              ) {
-                // console.error('Invalid input data');
-                return
-              }
-              this.setState({ vaultData })
-            } catch (err) {
-              if (err.name === 'SyntaxError') {
-                // Invalid JSON
-              } else {
-                console.error(err)
-              }
-            }
-          },
-        }),
-        h('br'),
+                    if (event.target.files.length) {
+                      const f = event.target.files[0]
+                      // TODO: handle other format
+                      // lmdb
+                      const data = await f.text()
+                      const vaultData = extractVaultFromLMDB(data)
+                      this.setState({ vaultData })
+                    }
+                  },
+                }),
+              ]),
+            ]),
+            h('tr', {}, [
+              h('td', {}, [
+                h('input', {
+                  id: 'radio-textinput',
+                  name: 'vault-source',
+                  type: 'radio',
+                  onChange: (event) => {
+                    if (event.target.checked) {
+                      this.setState({vaultSource: 'text'})
+                    }
+                  }
+                }),
+                h('label', {
+                  htmlFor: 'radio-textinput',
+                }, 'Paste text'),
+              ]),
+              h('td', {}, [
+                h('textarea.vault-data', {
+                  disabled: this.state.vaultSource !== 'text',
+                  id: 'textinput',
+                  style: {
+                    width: '600px',
+                    height: '300px'
+                  },
+                  placeholder: 'Paste your vault data here.',
+                  onChange: (event) => {
+                    try {
+                      const vaultData = JSON.parse(event.target.value)
+                      if (
+                        typeof vaultData !== 'object' ||
+                        !['data', 'iv', 'salt'].every(e => Object.keys(vaultData).includes(e))
+                      ) {
+                        // console.error('Invalid input data');
+                        return
+                      }
+                      this.setState({ vaultData })
+                    } catch (err) {
+                      if (err.name === 'SyntaxError') {
+                        // Invalid JSON
+                      } else {
+                        console.error(err)
+                      }
+                    }
+                  },
+                }),
+              ]),
+            ]),
+          ]),
+        ]),
 
         h('input.password', {
           type: 'password',

--- a/app/root.js
+++ b/app/root.js
@@ -85,7 +85,7 @@ AppRoot.prototype.render = function () {
                   type: 'radio',
                   onChange: (event) => {
                     if (event.target.checked) {
-                      this.setState({vaultSource: 'file'})
+                      this.setState({vaultSource: 'file', vaultData: null})
                     }
                   }
                 }),
@@ -145,7 +145,7 @@ AppRoot.prototype.render = function () {
                   type: 'radio',
                   onChange: (event) => {
                     if (event.target.checked) {
-                      this.setState({vaultSource: 'text'})
+                      this.setState({vaultSource: 'text', vaultData: null, fileValidation: null})
                     }
                   }
                 }),

--- a/app/root.js
+++ b/app/root.js
@@ -3,6 +3,7 @@ const Component = require('react').Component
 const h = require('react-hyperscript')
 const connect = require('react-redux').connect
 const passworder = require('@metamask/browser-passworder')
+const {extractVaultFromLMDB} = require('../lib/extract-lmdb-vault')
 
 module.exports = connect(mapStateToProps)(AppRoot)
 
@@ -56,6 +57,28 @@ AppRoot.prototype.render = function () {
         }, 'Fork on Github'),
         h('br'),
 
+        h('label', {
+          htmlFor: 'fileinput',
+        }, 'Database backup'),
+        h('input.file', {
+          id: 'fileinput',
+          type: 'file',
+          placeholder: 'file',
+          onChange: async (event) => {
+            // TODO: Clear error
+
+            if (event.target.files.length) {
+              const f = event.target.files[0]
+              // TODO: handle other format
+              // lmdb
+              const data = await f.text()
+              const vaultData = JSON.stringify(extractVaultFromLMDB(data))
+              this.setState({ vaultData })
+            }
+          },
+        }),
+        h('br'),
+
         h('textarea.vault-data', {
           style: {
             width: '600px',
@@ -97,7 +120,7 @@ AppRoot.prototype.render = function () {
 AppRoot.prototype.decrypt = function(event) {
   const { password, vaultData: vault } = this.state
 
-  passworder.decrypt(password, vault)
+  return passworder.decrypt(password, vault)
     .then((keyringsWithEncodedMnemonic) => {
       const keyringsWithDecodedMnemonic = keyringsWithEncodedMnemonic.map(keyring => {
         if ('mnemonic' in keyring.data) {

--- a/app/root.js
+++ b/app/root.js
@@ -145,18 +145,27 @@ AppRoot.prototype.render = function () {
                 }),
               ]),
             ]),
+            h('tr', {}, [
+              h('td', {}, [
+                h('label', {
+                  htmlFor: 'passwordinput',
+                }, 'Password'),
+              ]),
+              h('td', {}, [
+                h('input.password', {
+                  id: 'passwordinput',
+                  type: 'password',
+                  placeholder: 'Password',
+                  onChange: (event) => {
+                    const password = event.target.value
+                    this.setState({ password })
+                  },
+                }),
+              ]),
+            ]),
           ]),
         ]),
 
-        h('input.password', {
-          type: 'password',
-          placeholder: 'Password',
-          onChange: (event) => {
-            const password = event.target.value
-            this.setState({ password })
-          },
-        }),
-        h('br'),
 
         h('button.decrypt', {
           onClick: this.decrypt.bind(this),
@@ -167,8 +176,16 @@ AppRoot.prototype.render = function () {
           style: { color: 'red' },
         }, error) : null,
 
-        decrypted ? h('div', decrypted) : null,
-
+        decrypted ? h('div', {}, h('div', {
+                style: {
+                  backgroundColor: 'black',
+                  color: 'white',
+                  display: 'inline-block',
+                  fontFamily: 'monospace',
+                  margin: '1em',
+                  padding: '1em',
+                }
+              }, decrypted)) : null,
       ])
     ])
   )

--- a/app/root.js
+++ b/app/root.js
@@ -259,6 +259,10 @@ AppRoot.prototype.decrypt = function(event) {
       this.setState({ decrypted: serializedKeyrings })
     })
     .catch((reason) => {
+      if (reason.message === 'Incorrect password') {
+        this.setState({ error: reason.message })
+        return
+      }
       console.error(reason)
       this.setState({ error: 'Problem decoding vault.' })
     })

--- a/app/root.js
+++ b/app/root.js
@@ -139,6 +139,7 @@ AppRoot.prototype.decrypt = function(event) {
     return;
   }
 
+  this.setState({ error: null })
   return passworder.decrypt(password, JSON.stringify(vault))
     .then((keyringsWithEncodedMnemonic) => {
       const keyringsWithDecodedMnemonic = keyringsWithEncodedMnemonic.map(keyring => {

--- a/app/root.js
+++ b/app/root.js
@@ -119,6 +119,7 @@ AppRoot.prototype.render = function () {
 
         h('button.decrypt', {
           onClick: this.decrypt.bind(this),
+          disabled: !this.state.vaultData || !this.state.password,
         }, 'Decrypt'),
 
         error ? h('.error', {

--- a/app/root.js
+++ b/app/root.js
@@ -2,7 +2,7 @@ const inherits = require('util').inherits
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const connect = require('react-redux').connect
-const passworder = require('browser-passworder')
+const passworder = require('@metamask/browser-passworder')
 
 module.exports = connect(mapStateToProps)(AppRoot)
 

--- a/app/root.js
+++ b/app/root.js
@@ -119,8 +119,8 @@ AppRoot.prototype.render = function () {
                   disabled: this.state.vaultSource !== 'text',
                   id: 'textinput',
                   style: {
-                    width: '600px',
-                    height: '300px'
+                    width: '50em',
+                    height: '15em'
                   },
                   placeholder: 'Paste your vault data here.',
                   onChange: (event) => {

--- a/lib/extract-lmdb-vault.js
+++ b/lib/extract-lmdb-vault.js
@@ -1,7 +1,0 @@
-module.exports = {
-  extractVaultFromLMDB: (data) =>
-    data.match(/"KeyringController":{"vault":"{[^{}]*}"/)
-      .map(m => m.substring(29))
-      .map(s => JSON.parse(JSON.parse(s)))
-      [0]
-};

--- a/lib/extract-lmdb-vault.js
+++ b/lib/extract-lmdb-vault.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extractVaultFromLMDB: (data) =>
+    data.match(/"KeyringController":{"vault":"{[^{}]*}"/)
+      .map(m => m.substring(29))
+      .map(s => JSON.parse(JSON.parse(s)))
+      [0]
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "browser-passworder": "^2.0.3",
+        "@metamask/browser-passworder": "^4.0.2",
         "ethereumjs-util": "^7.1.4",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -46,6 +46,14 @@
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
+    "node_modules/@metamask/browser-passworder": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@metamask/browser-passworder/-/browser-passworder-4.0.2.tgz",
+      "integrity": "sha512-fC1EdXCd2nRZXCNcoCUODOV3p7dGkwYfWzZlqocBrckCv0+J6MQw2aIjFPER0laS/+OB86w89QFOtwzPZuuYkw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.0",
@@ -877,14 +885,6 @@
         "browser-pack": "bin/cmd.js"
       }
     },
-    "node_modules/browser-passworder": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/browser-passworder/-/browser-passworder-2.0.3.tgz",
-      "integrity": "sha1-b90gguUWoXbtvLPc7gt/n85PeRc=",
-      "dependencies": {
-        "browserify-unibabel": "^3.0.0"
-      }
-    },
     "node_modules/browser-resolve": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
@@ -1030,11 +1030,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "dev": true
-    },
-    "node_modules/browserify-unibabel": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-unibabel/-/browserify-unibabel-3.0.0.tgz",
-      "integrity": "sha1-WmuPD3BM44jTkn30czfiWDD3Hdo="
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
@@ -3455,6 +3450,11 @@
         }
       }
     },
+    "@metamask/browser-passworder": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@metamask/browser-passworder/-/browser-passworder-4.0.2.tgz",
+      "integrity": "sha512-fC1EdXCd2nRZXCNcoCUODOV3p7dGkwYfWzZlqocBrckCv0+J6MQw2aIjFPER0laS/+OB86w89QFOtwzPZuuYkw=="
+    },
     "@types/bn.js": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
@@ -4243,14 +4243,6 @@
         "umd": "^3.0.0"
       }
     },
-    "browser-passworder": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/browser-passworder/-/browser-passworder-2.0.3.tgz",
-      "integrity": "sha1-b90gguUWoXbtvLPc7gt/n85PeRc=",
-      "requires": {
-        "browserify-unibabel": "^3.0.0"
-      }
-    },
     "browser-resolve": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
@@ -4426,11 +4418,6 @@
           "dev": true
         }
       }
-    },
-    "browserify-unibabel": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-unibabel/-/browserify-unibabel-3.0.0.tgz",
-      "integrity": "sha1-WmuPD3BM44jTkn30czfiWDD3Hdo="
     },
     "browserify-zlib": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Dan Finlay",
   "license": "ISC",
   "dependencies": {
-    "browser-passworder": "^2.0.3",
+    "@metamask/browser-passworder": "^4.0.2",
     "ethereumjs-util": "^7.1.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",


### PR DESCRIPTION
Preview: https://legobeat.github.io/vault-decryptor/

The current guide advises the user to open a file in a text editor and cut out a specific json blob. This adds the option to upload a file directly and extract the vault from that.

Testing from Windows / mac users (esp from older versions) would be good. This has been tested with an mm extension db on Chrome on Linux (UPDATE: and Windows). It also recognizes vault directly in JSON format (same as textarea).


Also:

* Disable "decrypt" button when either password or vault missing or invalid
* Clear error messages on success
* Tell the user when the password is invalid (instead of generic message)
* Rudimentary input validation and sanitation

Preceded by #40, #42
![Screenshot 2022-12-15 at 18-12-43 MetaMask Vault Decryptor](https://user-images.githubusercontent.com/109787230/207820257-1e5f7eb5-c2c8-4fd5-97b4-03297452a380.png)
![Screenshot 2022-12-15 at 18-12-06 MetaMask Vault Decryptor](https://user-images.githubusercontent.com/109787230/207820260-316d5473-e9fc-435b-b0bb-f15bef8e7951.png)
![Screenshot 2022-12-15 at 18-13-14 MetaMask Vault Decryptor](https://user-images.githubusercontent.com/109787230/207820251-b7b2f858-e024-4f42-b507-85a7dee1d7d2.png)
