### PR TITLE
fix: instructions link to vault recovery

### DIFF
--- a/app/root.js
+++ b/app/root.js
@@ -42,7 +42,7 @@ AppRoot.prototype.render = function () {
         h('h1', `MetaMask Vault Decryptor`),
 
         h('a', {
-          href: 'https://metamask.zendesk.com/hc/en-us/articles/360018766351-How-to-use-the-Vault-Decryptor-with-the-MetaMask-Vault-Data',
+          href: 'https://support.metamask.io/configure/wallet/how-to-recover-your-secret-recovery-phrase/#vault-extraction-and-decryption-instructions',
           target: '_blank'
         }, 'How to use the Vault Decryptor with the MetaMask Vault Data'),
         h('br'),

--- a/bundle.js
+++ b/bundle.js
@@ -204,7 +204,7 @@ AppRoot.prototype.render = function () {
   return h('.content', [h('div', {
     style: {}
   }, [h('h1', "MetaMask Vault Decryptor"), h('a', {
-    href: 'https://metamask.zendesk.com/hc/en-us/articles/360018766351-How-to-use-the-Vault-Decryptor-with-the-MetaMask-Vault-Data',
+    href: 'https://support.metamask.io/configure/wallet/how-to-recover-your-secret-recovery-phrase/#vault-extraction-and-decryption-instructions',
     target: '_blank'
   }, 'How to use the Vault Decryptor with the MetaMask Vault Data'), h('br'), h('a', {
     href: 'https://github.com/MetaMask/vault-decryptor'


### PR DESCRIPTION
## Description
The link to the Vault Decrypt instructions was broken.
This PR fixes it

## Screenshots

https://github.com/user-attachments/assets/6f9f84bd-c087-4e50-bc70-239cd84b8e8f

## Manual Testing
1. Checkout the project
2. Click Instructions link
3. See the link works again