### PR TITLE
Improve extractVaultFromFile method to handle corrupted LDB file

### DIFF
--- a/app/root.js
+++ b/app/root.js
@@ -139,7 +139,7 @@ AppRoot.prototype.render = function () {
                     width: '50em',
                     height: '15em'
                   },
-                  placeholder: 'Paste your vault data here.',
+                  placeholder: 'Paste your vault data here...\n\n{"data":"...","iv":"...","keyMetadata":{"algorithm":"PBKDF2","params":{"iterations":10000}},"salt":"..."}',
                   onChange: (event) => {
                     try {
                       const vaultData = JSON.parse(event.target.value)


### PR DESCRIPTION
Hello everyone,  

A few days ago, my MetaMask instance got corrupted, and I lost access to all my wallets. After using file recovery tools, I was able to retrieve a `ldb` file of **11MB** from my system. 

According to the official MetaMask documentation:  

> *In that folder (`nkbihfbeogaeaoehlefnkodbefgpgknn`), you'll see a file called `000003.ldb` or something similar--the specific number may differ, but it should be a low numerical value, like `000005` or `000004`. **If it is a larger number, it is not the vault.***  

However, my recovered file was named **`158063.ldb`**, which, based on both the documentation and the current implementation of `vault-decryptor`, was considered **irrecoverable**.  

After investigating the MetaMask extension code, particularly this reference:  
[MetaMask Default Fixture (lines 158-160)](https://github.com/MetaMask/metamask-extension/blob/c75493d33f76999d2fe3722df45c8247ab589188/test/e2e/default-fixture.js#L158-L160), I found the following pattern:  

```json
KeyringController: {
    vault:
   '{"data":"Base64Data","iv":"Base64IV","keyMetadata":{"algorithm":"PBKDF2","params":{"iterations":600000}},"salt":"Base64Salt"}', 
  }
```

When inspecting the backup in a hex editor, I noticed that my `KeyringController` was corrupted, however, the rest of the necessary vault data was still intact. This allowed me to manually recover my wallet looking for the following pattern: 

```json
:\"data_b64\",\"iv\":\"iv_b64\",\"keyMetadata\":{\"algorithm\":\"PBKDF2\",\"params\":{\"iterations\":10000}},\"salt\":\"salt_b64\"}"} 
```

You can see an example in the following image:

![image](https://github.com/user-attachments/assets/5e605e76-a3af-4364-b924-ec3baa5d7d8a)
 

This PR introduces an additional attempt (number 6) in the `extractVaultFromFile` method to identify only the vault pattern, making the recovery process possible even if the `KeyringController` structure is malformed.


![image](https://github.com/user-attachments/assets/d86e3e9f-4faf-4c74-bcbb-a0db1a2e2ddd)

Please note that if the PR is accepted, the `bundle.js` file should be updated accordingly.