### PR TITLE
fix: scenario with keyringsMetadata

### DIFF
--- a/app/lib.js
+++ b/app/lib.js
@@ -88,7 +88,35 @@ function extractVaultFromFile (data) {
       }
     }
   }
-  // attempt 5: chromium 000005.ldb on windows
+  {
+    // attempt 5: chromium 0000056.log on MacOS
+    // This variant is very similar to attempt 4 but there is the addition of a new metadata field, keyringsMetadata, in the vault.
+    const matches = data.match(/"KeyringController":\{.*?"vault":"({.*})"},/);
+    if (matches && matches.length) {
+      try {
+        const keyringControllerStateFragment = matches[1];
+        const dataRegex = /\\"data\\":\\"([A-Za-z0-9+\/]*=*)/u;
+        const ivRegex = /,\\"iv\\":\\"([A-Za-z0-9+\/]{10,40}=*)/u;
+        const saltRegex = /,\\"salt\\":\\"([A-Za-z0-9+\/]{10,100}=*)\\"/;
+        const keyMetaRegex = /,\\"keyMetadata\\":(.*}})/;
+
+        const vaultParts = [dataRegex, ivRegex, saltRegex, keyMetaRegex]
+          .map((reg) => keyringControllerStateFragment.match(reg))
+          .map((match) => match[1]);
+
+        return {
+          data: vaultParts[0],
+          iv: vaultParts[1],
+          salt: vaultParts[2],
+          keyMetadata: JSON.parse(vaultParts[3].replaceAll("\\", "")),
+        };
+      } catch (err) {
+        // Not valid JSON: continue
+      }
+    }
+  }
+
+  // attempt 6: chromium 000005.ldb on windows
   const matchRegex = /Keyring[0-9][^\}]*(\{[^\{\}]*\\"\})/gu
   const captureRegex  = /Keyring[0-9][^\}]*(\{[^\{\}]*\\"\})/u
   const ivRegex = /\\"iv.{1,4}[^A-Za-z0-9+\/]{1,10}([A-Za-z0-9+\/]{10,40}=*)/u

--- a/app/lib.test.js
+++ b/app/lib.test.js
@@ -37,7 +37,13 @@ const FIXTURES = [
     path: 'chromium-120.0.6099.71-macos-arm64/000003.log',
     mnemonic: 'because carpet thought flame ride regular wink weather lazy spice unveil device',
     passphrase: 'correct horse battery staple',
-  }
+  },
+  {
+    path: 'chrome-133.0.6943.127-macos-arm64/000052.log',
+    mnemonic:
+      'slight escape bracket joy globe bring teach exact mango mansion injury category',
+    passphrase: 'password',
+  },
 ]
 
 const VAULTS = [

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.73,
+      branches: 95.23,
       functions: 100,
-      lines: 98.27,
-      statements: 98.38,
+      lines: 98.57,
+      statements: 98.64,
     },
   },
 


### PR DESCRIPTION
This PR adds a new scenario to allow users to backup with a vault that contains the `keyringsMetadata`. This new state was added in the [release 303.0.0](https://github.com/MetaMask/core/commit/68fa31a5e3307a4ab400b3412d9589ea116a28b9)