### PR TITLE
Add yarn resolution for `elliptic@^6.6.1` to fix critical security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   },
   "author": "Dan Finlay",
   "license": "ISC",
+  "resolutions": {
+    "elliptic": "^6.6.1"
+  },
   "dependencies": {
     "@metamask/browser-passworder": "^4.3.0",
     "ethereumjs-util": "^7.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,9 +3241,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.5.3, elliptic@npm:^6.5.4, elliptic@npm:^6.5.7":
-  version: 6.6.0
-  resolution: "elliptic@npm:6.6.0"
+"elliptic@npm:^6.6.1":
+  version: 6.6.1
+  resolution: "elliptic@npm:6.6.1"
   dependencies:
     bn.js: ^4.11.9
     brorand: ^1.1.0
@@ -3252,7 +3252,7 @@ __metadata:
     inherits: ^2.0.4
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
-  checksum: e912349b883e694bfe65005214237a470c9a098a6ba36fd24396d0ab07feb399920c0738aeed1aed6cf5dca9c64fd479e212faed3a75c9d81453671ef0de5157
+  checksum: 27b14a52f68bbbc0720da259f712cb73e953f6d2047958cd02fb0d0ade2e83849dc39fb4af630889c67df8817e24237428cf59c4f4c07700f755b401149a7375
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- See https://github.com/advisories/GHSA-vjh7-7g9h-fjfh
- See https://github.com/MetaMask/supply-chain-tracker/issues/1